### PR TITLE
Removed extra UTF-8 encoding on name/description fields

### DIFF
--- a/library-docker/Dockerfile
+++ b/library-docker/Dockerfile
@@ -7,7 +7,10 @@ LABEL maintainer="kiwix"
 ENV VERSION_KIWIX_TOOLS 0.8.0
 ENV LIBRARY_DIR /var/www/library.kiwix.org
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget cron libfindbin-libs-perl libxml-dom-xpath-perl libdatetime-perl liblocales-perl libnumber-bytes-human-perl libxml-simple-perl libgetargs-long-perl libxml2-utils python3 python3-yaml python3-requests python3-pycountry 
+RUN apt-get update && apt-get install -y --no-install-recommends wget cron libfindbin-libs-perl libxml-dom-xpath-perl libdatetime-perl liblocales-perl libnumber-bytes-human-perl libxml-simple-perl libgetargs-long-perl libxml2-utils python3 python3-pip
+
+RUN pip3 install -U pip setuptools
+RUN pip3 install pycountry==18.2.23 PyYAML==3.12 requests==2.18.4
 
 RUN wget --no-check-certificate -q -O kiwix-tools.tar.gz http://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-x86_64-$VERSION_KIWIX_TOOLS.tar.gz \
   && tar --strip=1 -xzf kiwix-tools.tar.gz -C /usr/local/bin/ kiwix-tools_linux-x86_64-$VERSION_KIWIX_TOOLS/kiwix-serve \

--- a/library-docker/bin/library-to-catalog.py
+++ b/library-docker/bin/library-to-catalog.py
@@ -235,8 +235,8 @@ def convert(library_fpath, catalog_fpath,
             langid = kind
 
         catalog[langid] = {
-            'name': name.encode('utf-8'),
-            'description': description.encode('utf-8'),
+            'name': name,
+            'description': description,
             'version': version,
             'language': lang_3,
             'id': bid,
@@ -252,9 +252,7 @@ def convert(library_fpath, catalog_fpath,
     logger.info("dumping yaml content to file `{}`".format(catalog_fpath))
     with open(catalog_fpath, 'w') as fd:
         yaml.safe_dump({'all': catalog}, fd,
-                       default_flow_style=False,
-                       allow_unicode=True,
-                       encoding="utf-8")
+                       default_flow_style=False)
 
     logger.info("done converting library to catalog.")
 


### PR DESCRIPTION
This extra encoding (the file is already UTF-8 encoded) makes PyYAML encode it as binary
Data from those fields is thus not directly readable

Code was already compat with py2 (used on previous server) and py3 (used in this container).
Python version bundled in this container has a different behavior ; fixed by changing `yaml.safe_dump()` params.

Tested inside the container ; confirms it now works as expected.

Please **merge and deploy** ASAP as this break kiwix-hotspot