### PR TITLE
Default server for reverse-proxy

### DIFF
--- a/reverse-proxy-docker/sites/default_server
+++ b/reverse-proxy-docker/sites/default_server
@@ -1,0 +1,6 @@
+server {
+  listen *:80 default_server;
+  server_name _;
+
+  return    404;
+}


### PR DESCRIPTION
Add a default_server so incorrect-domain requests don't end up on first server (download.openzim.org)