### PR TITLE
Added application/atom+xml to allow compression of OPDS content

### DIFF
--- a/reverse-proxy-docker/Dockerfile
+++ b/reverse-proxy-docker/Dockerfile
@@ -13,7 +13,7 @@ RUN { \
 RUN { \
     echo "gzip on;" ; \
     echo "gzip_proxied any;" ; \
-    echo "gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype;" ; \
+    echo "gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype application/atom+xml text/html;" ; \
 } > /etc/nginx/conf.d/05gzip.conf
 
 COPY sites/* /etc/nginx/sites-enabled/


### PR DESCRIPTION
Previous PR from @kelson42 fixed the binary being compressed issue but did not include the proper MIME for OPDS (`application/atom+xml`). I also added `text/html`.

`Content-Type: application/atom+xml;profile=opds-catalog;kind=acquisition; charset=utf-8`