### PR TITLE
Enable gzip compression for YAML library

### DIFF
--- a/reverse-proxy-docker/Dockerfile
+++ b/reverse-proxy-docker/Dockerfile
@@ -13,8 +13,10 @@ RUN { \
 RUN { \
     echo "gzip on;" ; \
     echo "gzip_proxied any;" ; \
-    echo "gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype application/atom+xml text/html;" ; \
+    echo "gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype application/atom+xml text/html text/yaml;" ; \
 } > /etc/nginx/conf.d/05gzip.conf
+
+RUN sed -i '4i \    text/yaml                                        yml;' /etc/nginx/mime.types
 
 COPY sites/* /etc/nginx/sites-enabled/
 


### PR DESCRIPTION
Although it is temporary (until we switch to OPDS), we shall enable web-server compression on `ideascube.yml` as it is currently 1.1MB large.

Since this content is served by mirror, we can only act on `mirror.download`.

On this server, compression is already enabled but it doesn't apply to `ideascube.yml`:

```
curl -I -H "Accept-encoding: gzip" http://mirror.download.kiwix.org/library/library_zim.xml
Content-Type: text/xml
Content-Encoding: gzip
```

```
curl -I -H "Accept-encoding: gzip" http://mirror.download.kiwix.org/library/ideascube.yml
Content-Type: application/octet-stream
```

FYI, mime is wrong for this file:
```
file -i /data/download/library/ideascube.yml
/data/download/library/ideascube.yml: text/x-makefile; charset=us-ascii
```

This PR adds a new mime `text/yaml` for files with extension `.yml` and adds `text/yaml` to the list of to-gzip content types.

Note: this will apply to all sites served by this reverse proxy, but it's harmless.