### PR TITLE
add nginx user to group users

### DIFF
--- a/reverse-proxy-docker/Dockerfile
+++ b/reverse-proxy-docker/Dockerfile
@@ -2,6 +2,8 @@ FROM jwilder/nginx-proxy
 
 RUN apt-get update && apt-get install -y --no-install-recommends cron logrotate
 
+RUN usermod -a -G users nginx
+
 RUN { \
     echo "include /etc/nginx/sites-enabled/*;" ; \
 } > /etc/nginx/conf.d/10sites_alias.conf


### PR DESCRIPTION
Adding user `nginx` to the `users` (`gid 100`) group in its image to fix openzim/zimfarm/issues/374 (explaination there)