### PR TITLE
Fixes #123: include matomo nginx vhost to repo

### DIFF
--- a/matomo-server-docker/data/web/vhost.d/matomo.conf
+++ b/matomo-server-docker/data/web/vhost.d/matomo.conf
@@ -1,0 +1,44 @@
+server {
+
+  listen [::]:80;
+  listen 80;
+
+  server_name stats.kiwix.org;
+  root /var/www/html/;
+  index index.php;
+
+  client_body_buffer_size 1M;  # was 16k
+
+  location ~ ^/(index|matomo|piwik|js/index).php {
+        fastcgi_pass matomo_app:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_read_timeout 600;
+  }
+
+  location ~* ^.+\.php$ {
+    deny all;
+    return 403;
+  }
+
+  location / {
+    try_files $uri $uri/ =404;
+  }
+
+  location ~ /(config|tmp|core|lang) {
+    deny all;
+    return 403;
+  }
+
+  location ~ \.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2|json)$ {
+    allow all;
+  }
+
+  location ~ /(libs|vendor|plugins|misc/user) {
+    deny all;
+    return 403;
+  }
+
+}

--- a/matomo-server-docker/docker-compose.yml
+++ b/matomo-server-docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "/data/matomo/mysql/conf:/etc/mysql/conf.d"
       - "/data/matomo/mysql/files:/var/lib/mysql"
     environment:
-      - MYSQL_ROOT_PASSWORD=root      
+      - MYSQL_ROOT_PASSWORD=root
     restart: always
 
   app:
@@ -22,14 +22,14 @@ services:
     environment:
       - MATOMO_URL=http://stats
     restart: always
-    
+
   web:
     image: nginx:latest
     container_name: matomo_web
     volumes:
       - "appdir:/var/www/html"
       - "/data/matomo/data:/var/www/html/misc/user"
-      - "/data/matomo/web/conf:/etc/nginx/conf.d"
+      - "./data/web/vhost.d:/etc/nginx/conf.d"
     links:
       - app
     environment:
@@ -42,7 +42,7 @@ services:
         aliases:
           - stats
     restart: always
-    
+
 volumes:
   appdir:
 


### PR DESCRIPTION
* added nginx vhost conf into repo
* changed volume to point to this folder
* changed `client_body_buffer_size` for performance:

matomo web server logs are full of warnings like

```
172.31.0.10 - - [31/Mar/2020:08:17:21 +0000] "POST /piwik.php HTTP/1.1" 200 78 "-" "Matomo/LogImport" "-"
2020/03/31 08:17:21 [warn] 8#8: *5757212 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000391690, client: 172.31.0.10, server: stats.kiwix.org, request: "POST /piwik.php HTTP/1.1", host: "stats.kiwix.org"
```

This means that for every request of the matomo log import script (every 200 lines of log), nginx has to write the request to the disk and read it from there and delete it after passing it to php. It's a big waste of resources and dramatically slows down the import process from the tests I conducted on my machine.