### PR TITLE
Varnish cache frontend

### DIFF
--- a/campusafrica/kalite-docker/kalite-setup.sh
+++ b/campusafrica/kalite-docker/kalite-setup.sh
@@ -7,9 +7,9 @@ function die() {
     exit 1
 }
 
-if [ -f /var/run/secrets/kalite-password ]
+if [ -f /run/secrets/kalite-password ]
 then
-    ADMIN_PASSWORD=$(cat /var/run/secrets/kalite-password)
+    ADMIN_PASSWORD=$(cat /run/secrets/kalite-password)
 fi
 
 function importlangpack() {

--- a/campusafrica/logger/entrypoint.sh
+++ b/campusafrica/logger/entrypoint.sh
@@ -2,10 +2,10 @@
 
 echo "Initializing logger container"
 
-if [ -f /var/run/secrets/matomo-token ]
+if [ -f /run/secrets/matomo-token ]
 then
     echo " .. reading matomo secret"
-    export MATOMO_TOKEN=$(cat /var/run/secrets/matomo-token)
+    export MATOMO_TOKEN=$(cat /run/secrets/matomo-token)
 fi
 
 echo " .. dumping envs to default"

--- a/library-docker/Dockerfile
+++ b/library-docker/Dockerfile
@@ -7,9 +7,15 @@ LABEL maintainer="kiwix"
 
 ENV VERSION_KIWIX_TOOLS 3.1.1-3
 ENV LIBRARY_DIR /var/www/library.kiwix.org
+ENV VERSION_VARNISH 6.4.0-1~stretch_amd64
+ENV VARNISH_SECRET notset
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget cron libfindbin-libs-perl libxml-dom-xpath-perl libdatetime-perl liblocales-perl libnumber-bytes-human-perl libxml-simple-perl libgetargs-long-perl libxml2-utils python3 python3-pip && \
+    apt-get install -y --no-install-recommends wget cron curl libfindbin-libs-perl \
+    libxml-dom-xpath-perl libdatetime-perl liblocales-perl libnumber-bytes-human-perl \
+    libxml-simple-perl libgetargs-long-perl libxml2-utils python3 python3-pip && \
+    wget -o -L --content-disposition https://packagecloud.io/varnishcache/varnish64/packages/debian/stretch/varnish_$VERSION_VARNISH.deb/download.deb && \
+    apt-get install -y -f ./varnish_$VERSION_VARNISH.deb && rm varnish_$VERSION_VARNISH.deb && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -26,11 +32,15 @@ EXPOSE 80
 
 WORKDIR $LIBRARY_DIR
 
-#Install start script
+# Copy Perl modules
+COPY lib/Mediawiki/Mediawiki.pm /usr/share/perl5/Mediawiki/Mediawiki.pm
+
+# Copy varnish config
+COPY varnish/default.vcl /etc/varnish/default.vcl
+
+# Install start script
 COPY bin/ /usr/local/bin/
 RUN chmod -R 0500 /usr/local/bin/*
 
-#Copy Perl modules
-COPY lib/Mediawiki/Mediawiki.pm /usr/share/perl5/Mediawiki/Mediawiki.pm
-
-CMD start.sh
+ENTRYPOINT ["start.sh"]
+CMD ["/usr/sbin/varnishd", "-F", "-a", ":80", "-T", "localhost:6082", "-f", "/etc/varnish/default.vcl", "-S", "/etc/varnish/secret", "-s", "malloc,256m"]

--- a/library-docker/Dockerfile
+++ b/library-docker/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 #
 LABEL maintainer="kiwix"
 
-ENV VERSION_KIWIX_TOOLS 3.1.1-3
+ENV VERSION_KIWIX_TOOLS 3.1.1-4
 ENV LIBRARY_DIR /var/www/library.kiwix.org
 ENV VERSION_VARNISH 6.4.0-1~stretch_amd64
 ENV VARNISH_SECRET notset

--- a/library-docker/bin/restart-kiwix-serve.sh
+++ b/library-docker/bin/restart-kiwix-serve.sh
@@ -3,7 +3,7 @@
 export PATH=/usr/local/bin:/usr/sbin:$PATH
 
 start () {
-  stop  
+  stop
   echo "Starting kiwix-serve..."
   kiwix-serve --daemon --port=8000 --library --threads=16 --verbose --nodatealias library.kiwix.org.xml
 }

--- a/library-docker/bin/restart-kiwix-serve.sh
+++ b/library-docker/bin/restart-kiwix-serve.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export PATH=/usr/local/bin:/usr/sbin:$PATH
+
+start () {
+  stop  
+  echo "Starting kiwix-serve..."
+  kiwix-serve --daemon --port=8000 --library --threads=16 --verbose --nodatealias library.kiwix.org.xml
+}
+
+stop () {
+  pid=$(pidof kiwix-serve)
+  if [ ! -z $pid ];
+  then
+    echo "Stopping kiwix-serve..."
+    kill -9 $pid
+  fi
+}
+
+is_alive () {
+  echo "Testing kiwix-serve..."
+  curl --max-time 50 http://localhost:8000/catalog/searchdescription.xml > /dev/null 2>&1
+  return $?
+}
+
+is_alive || start

--- a/library-docker/bin/restart-kiwix-serve.sh
+++ b/library-docker/bin/restart-kiwix-serve.sh
@@ -5,22 +5,66 @@ export PATH=/usr/local/bin:/usr/sbin:$PATH
 start () {
   stop
   echo "Starting kiwix-serve..."
-  kiwix-serve --daemon --port=8000 --library --threads=16 --verbose --nodatealias library.kiwix.org.xml
-}
-
-stop () {
-  pid=$(pidof kiwix-serve)
-  if [ ! -z $pid ];
-  then
-    echo "Stopping kiwix-serve..."
-    kill -9 $pid
+  kiwix-serve --daemon --port=8000 --library --threads=16 --nodatealias /var/www/library.kiwix.org/library.kiwix.org.xml
+  is_loaded
+  if [ $? -eq 0 ] ; then
+    echo "kiwix-serve ready, clearing varnish cache"
+    varnish-clear
   fi
 }
 
-is_alive () {
+stop () {
+  echo "Stopping kiwix-serve..."
+  # kills all kiwix-serve instances if present. nothing if not
+  kill -9 $(pidof kiwix-serve) > /dev/null 2>&1
+}
+
+test_url_until () {
+  url=$1
+  timeout=$2
+  retries=$3
+  duration=$4
+
+  attempt=1
+  res=1
   echo "Testing kiwix-serve..."
-  curl --max-time 50 http://localhost:8000/catalog/searchdescription.xml > /dev/null 2>&1
+  while [ $attempt -le $retries ]
+  do
+    echo "..attempt $attempt"
+    curl --max-time $timeout $url > /dev/null 2>&1
+    res=$?
+    if [ $res -eq 7 ];  # can't connect, either not launched or starting
+    then
+      ((attempt++))
+      sleep $duration
+    else
+      echo "... can connect with $res"
+      return $res
+    fi
+  done
+  echo ".. exhausted attempts with $res"
+  return $res
+}
+
+is_alive () {
+  # check descriptor for 10s sleeping for 1s with a timeout of 10s
+  test_url_until "http://localhost:8000/catalog/searchdescription.xml" 10 10 1
   return $?
 }
 
-is_alive || start
+is_loaded () {
+  # check OPDS root for 5mn sleeping for 10s with a timeout of 30s
+  test_url_until "http://localhost:8000/catalog/root.xml" 30 30 10
+  return $?
+}
+
+exec 100>/var/lock/kiwix-serve || exit 1
+flock -n 100 || exit 1
+# passing "restart" requests a restart even if kiwix-serve alive
+if [ "$1" = "restart" ];
+then
+  start
+else
+  is_alive || start
+fi
+flock -u 100

--- a/library-docker/bin/restart-kiwix-serve.sh
+++ b/library-docker/bin/restart-kiwix-serve.sh
@@ -54,7 +54,7 @@ is_alive () {
 
 is_loaded () {
   # check OPDS root for 5mn sleeping for 10s with a timeout of 30s
-  test_url_until "http://localhost:8000/catalog/root.xml" 30 30 10
+  test_url_until "http://localhost:8000/catalog/root.xml" 30 15 5
   return $?
 }
 

--- a/library-docker/bin/start.sh
+++ b/library-docker/bin/start.sh
@@ -7,15 +7,14 @@ Disallow: /
 " > /var/www/library.kiwix.org/robots.txt
 
 printf "#!/bin/sh
-/usr/bin/varnishreload
+/usr/sbin/varnishreload
 echo 'ban req.url ~ "^.*$"' | /usr/bin/varnishadm -T localhost:6082 -S /etc/varnish/secret
 " > /usr/local/bin/varnish-clear && chmod 0500 /usr/local/bin/varnish-clear
 
 printf "#!/bin/sh
 cd $LIBRARY_DIR
 manageLibraryKiwixOrg.pl --source=/var/www/download.kiwix.org/library/library_zim.xml >library.kiwix.org.xml 2>>/dev/shm/libgen
-kill \`pidof kiwix-serve\`
-/usr/local/bin/varnish-clear
+/usr/local/bin/restart-kiwix-serve.sh restart
 " > /etc/cron.daily/80generateLibraryKiwixOrg && chmod 0500 /etc/cron.daily/80generateLibraryKiwixOrg
 
 printf "#!/bin/sh
@@ -29,7 +28,7 @@ manageLibraryKiwixOrg.pl --source=/var/www/download.kiwix.org/library/library_zi
 
 echo "Generate crontab for kiwix-serve"
 printf "
-@reboot root /usr/local/bin/restart-kiwix-serve.sh
+@reboot root /usr/local/bin/restart-kiwix-serve.sh restart
 * * * * * root /usr/local/bin/restart-kiwix-serve.sh
 " > /etc/crontab
 

--- a/library-docker/bin/start.sh
+++ b/library-docker/bin/start.sh
@@ -3,7 +3,6 @@
 printf "
 # User-agent: *
 # Crawl-delay: 3
-User-agent: *
 Disallow: /
 " > /var/www/library.kiwix.org/robots.txt
 

--- a/library-docker/varnish/default.vcl
+++ b/library-docker/varnish/default.vcl
@@ -4,7 +4,7 @@ acl purge {
     "localhost";
 }
 
-backend default {  
+backend default {
     .host = "localhost";
     .port = "8000";
 
@@ -30,8 +30,8 @@ sub vcl_recv {
     # cache /skin/ (kiwix-serve toolbar)
     # cache /meta?content=xxxxxx&name=favicon (homepage favicons)
     # cache /catalog (OPDS)
-    if (req.url ~ "^/$" || 
-        req.url ~ "^/skin/" || 
+    if (req.url ~ "^/$" ||
+        req.url ~ "^/skin/" ||
         req.url ~ "^/meta\?content=[a-z0-9\-\_]+&name=favicon" ||
         req.url ~ "^/catalog/") {
         return(hash);
@@ -42,11 +42,10 @@ sub vcl_recv {
 }
 
 sub vcl_backend_response {
-    
     # kiwix-serve doesn't set cache-friendly headers (Cache-control: nocache)
     # caching toolbar, catalog and homepage for 1d
     if (bereq.url ~ "^/$" ||
-        bereq.url ~ "^/skin/" || 
+        bereq.url ~ "^/skin/" ||
         bereq.url ~ "^/catalog/") {
         unset beresp.http.set-cookie;
         unset beresp.http.Cache-Control;

--- a/library-docker/varnish/default.vcl
+++ b/library-docker/varnish/default.vcl
@@ -1,0 +1,56 @@
+vcl 4.0;
+
+acl purge {
+    "localhost";
+}
+
+backend default {  
+    .host = "localhost";
+    .port = "8000";
+
+    # .connect_timeout = 60s;
+    # .first_byte_timeout = 60s;
+    # .between_bytes_timeout = 60s;
+}
+
+sub vcl_recv {
+    # allow HTTP purge
+    # curl -X PURGE http://localhost/xxx to remove resource xxx from cache
+    if (req.method == "PURGE") {
+        if (!client.ip ~ purge) {
+            return(synth(405, "Not allowed."));
+        }
+        return (purge);
+    }
+
+    # set standard proxied ip header for getting original remote address
+    set req.http.X-Forwarded-For = client.ip;
+
+    # cache / (homepage)
+    # cache /skin/ (kiwix-serve toolbar)
+    # cache /meta?content=xxxxxx&name=favicon (homepage favicons)
+    # cache /catalog (OPDS)
+    if (req.url ~ "^/$" || 
+        req.url ~ "^/skin/" || 
+        req.url ~ "^/meta\?content=[a-z0-9\-\_]+&name=favicon" ||
+        req.url ~ "^/catalog/") {
+        return(hash);
+    }
+
+    # default to not caching (to save space)
+    return (pass);
+}
+
+sub vcl_backend_response {
+    
+    # kiwix-serve doesn't set cache-friendly headers (Cache-control: nocache)
+    # caching toolbar, catalog and homepage for 1d
+    if (bereq.url ~ "^/$" ||
+        bereq.url ~ "^/skin/" || 
+        bereq.url ~ "^/catalog/") {
+        unset beresp.http.set-cookie;
+        unset beresp.http.Cache-Control;
+        unset beresp.http.Age;
+        set beresp.ttl = 1d;
+    }
+}


### PR DESCRIPTION
Varnish config:
- homepage is cached for 1d
- /skin/* (toolbar stuff) is cached for 1d
- /catalog/* is cached for 1d
- homepage favicons
- all other requests are forwarded to kiwix-serve

Dockerfile updates:
- installed curl to fix is_alive kiwix-serve test (was broken)
- installed latest varnish version from upstream deb
- apt-install command split into multiple lines for readability
- added varnish clear cache on library update
- changed Dockerfile command to varnish

Having varnish as CMD is cleaner as we are now obeying docker convention to have one
main process for the image and this process responds friendly to stop requests (unlike kiwix-serve)

Entrypoint updates
- made start.sh the entrypoint instead of command (makes more sense)
- moved kiwix-serve startup/restart/watch to independent script (restart-kiwix-serve.sh)
- using printf instead of multiple echo for readability of cron.daily creations
- using a cron job for checking kiwix-serve everyminute instead of sleep loop

Kiwix-serve checker updates
- run on startup via cron
- run every minute via cron
- executes start() if timesout on test URL
- start() calls stop() before starting kiwix-serve
- kiwix-serve started on port 8000

Killing kiwix-serve before starting it up ensures the start is useless in the case
the process did not die but got stuck. Previous version did not.

How to tell is a resource was cached?
Check the response's header, for cached resources there are two headers:

* `X-Varnish` which contains one or two numbers. If there are two numbers, the resource was
retrieved from the cache. Those represent the request IDs of the current and the one which created the cache entry.
* `Age`: contains the age of the resource in the cache (seconds)

So:

* Two `X-Varnish` IDs and `Age` greater than 0: result from cache
* Single `X-Varnish` ID and `Age: 0`: result from backend

There's no way to be sure if the resource is in the to-cache list or not except by making two requests
and verifying that at least the second came from the cache.