### PR TITLE
gzip all requests on /catalog/ 

### DIFF
--- a/reverse-proxy-docker/Dockerfile
+++ b/reverse-proxy-docker/Dockerfile
@@ -15,7 +15,7 @@ RUN { \
 RUN { \
     echo "gzip on;" ; \
     echo "gzip_proxied any;" ; \
-    echo "gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/rss+xml application/opensearchdescription+xml text/javascript image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype application/atom+xml text/html text/yaml text/tab-separated-values;" ; \
+    echo "gzip_types application/rss+xml application/opensearchdescription+xml image/svg+xml application/vnd.ms-fontobject application/x-font-ttf font/opentype application/atom+xml text/yaml text/tab-separated-values;" ; \
 } > /etc/nginx/conf.d/05gzip.conf
 
 RUN sed -i '4i \    text/yaml                                        yml;' /etc/nginx/mime.types

--- a/reverse-proxy-docker/sites/library.kiwix.org_location
+++ b/reverse-proxy-docker/sites/library.kiwix.org_location
@@ -1,0 +1,6 @@
+location /catalog/ {
+    proxy_pass http://library.kiwix.org;
+    gzip on;
+    gzip_proxied any;
+    gzip_types "*";
+}


### PR DESCRIPTION
For some reason, nginx is not capable of correctly matching our OPDS response with the
`application/atom+xml` mime-type, resulting in those requests being excluded from the gzip compression
That's because we list the `gzip_types` with support ; including `application/atom+xml`.

Kiwix-serve's response have a `Content-Type: application/atom+xml;profile=opds-catalog;kind=acquisition; charset=utf-8` which is correct according to [Wikipedia](https://en.wikipedia.org/wiki/Open_Publication_Distribution_System): `application/atom+xml;profile=opds-catalog` and [the spec](https://specs.opds.io/opds-1.2.html)

It is possible nginx only removes the part after the last `;` character to extract the mime-type from `Content-Type` header.
Nginx having a limitation in the number of character for a mime-type and that number [not being configurable](https://trac.nginx.org/nginx/ticket/203), it is not possible to define `application/atom+xml;profile=opds-catalog` as a candidate-type for compression.

This renders picking this type impossible. This behavior continues with nginx 1.19 (we're currenlty using 1.17.4).

To overcome this limitation, we are using `gzip_types "*"` which compresses all responses, regarless of their type.
This is defined only within the `/catalog` prefix, which serves the OPDS.

Given `location` directives doesn't inherit from one-another, we have to define the `proxy_pass` manually here which is not elegant (that's nginx-proxy's job) but couldn't find a better way. It's very simple and predictable though.