### PR TITLE
Move gzip-opds to reverse-proxy's entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     container_name: reverse-proxy
     volumes:
       - "/var/run/docker.sock:/tmp/docker.sock:ro"
-      - "./vhost.d:/etc/nginx/vhost.d:rw"
+      - "vhost:/etc/nginx/vhost.d"
       - "/data/html:/usr/share/nginx/html"
       - "/data/openzim:/var/www/download.openzim.org"
       - "/data/download:/var/www/download.kiwix.org"
@@ -99,7 +99,7 @@ services:
       - reverse-proxy
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "./vhost.d:/etc/nginx/vhost.d:rw"
+      - "vhost:/etc/nginx/vhost.d"
       - "/data/html:/usr/share/nginx/html"
       - "/data/certs:/etc/nginx/certs:rw"
     restart: always
@@ -198,6 +198,8 @@ services:
       - MASQUERADE_ADDRESS=195.154.156.115
     restart: always
 
+volumes:
+  vhost:
 secrets:
   matomo-token:
     file: ./matomo-token.txt

--- a/reverse-proxy-docker/docker-entrypoint.sh
+++ b/reverse-proxy-docker/docker-entrypoint.sh
@@ -36,6 +36,12 @@ fi
 } > /etc/nginx/vhost.d/library.kiwix.org
 
 { \
+  echo "location /catalog/ {" ; \
+  echo "  proxy_pass http://library.kiwix.org;" ; \
+  echo "  gzip on;" ; \
+  echo "  gzip_proxied any;" ; \
+  echo '  gzip_types "*";' ; \
+  echo "}" ; \
   echo "location /robots.txt {" ; \
   echo "  alias /var/www/library.kiwix.org/robots.txt;" ; \
   echo "}" ; \

--- a/vhost.d/library.kiwix.org_location
+++ b/vhost.d/library.kiwix.org_location
@@ -1,6 +1,0 @@
-location /catalog/ {
-    proxy_pass http://library.kiwix.org;
-    gzip on;
-    gzip_proxied any;
-    gzip_types "*";
-}


### PR DESCRIPTION
Actually, the custom reverse-proxy-docker image overwrites the `/etc/nginx/vhost.d/library.kiwix.org_location` file on startup so that's the place to insert our catalog rule.

Given this is in the image, reverting previous changes to docker-compose and repo.