### PR TITLE
Fix open files issue with kiwix-serve library

### DIFF
--- a/library-docker/Dockerfile
+++ b/library-docker/Dockerfile
@@ -39,6 +39,8 @@ COPY lib/Mediawiki/Mediawiki.pm /usr/share/perl5/Mediawiki/Mediawiki.pm
 # Copy varnish config
 COPY varnish/default.vcl /etc/varnish/default.vcl
 
+RUN printf "* soft nofile 42000\n" > /etc/security/limits.conf
+
 # Install start script
 COPY bin/ /usr/local/bin/
 RUN chmod -R 0500 /usr/local/bin/*


### PR DESCRIPTION
kiwix-serve being started via cron, its process doesn't inherit the host's docker
limits but uses the ones defined in its `/etc/security/limits.conf`.
As this was empty, it defaulted to `1024` open files.

By setting this to `42000` (value copied from host) kiwix-serve can open its many fds.
Tests showed with current library, it needs under 7,000.