### PR TITLE
Apply nofile limits to root user as well

### DIFF
--- a/library-docker/Dockerfile
+++ b/library-docker/Dockerfile
@@ -39,7 +39,7 @@ COPY lib/Mediawiki/Mediawiki.pm /usr/share/perl5/Mediawiki/Mediawiki.pm
 # Copy varnish config
 COPY varnish/default.vcl /etc/varnish/default.vcl
 
-RUN printf "* soft nofile 42000\n" > /etc/security/limits.conf
+RUN printf "* - nofile 42000\nroot - nofile 42000" > /etc/security/limits.conf
 
 # Install start script
 COPY bin/ /usr/local/bin/


### PR DESCRIPTION
Fixes #148 

I am not sure why it used to work and why it failed to work but also setting the soft limit for the root user prevents it from falling into the default `1024` open fds.

Tested online, currently works as expected.