### PR TITLE
disabled quarantine for now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       - "/data/quarantine/zim:/mnt/quarantine:rw"
       - "/data/download/zim:/mnt/zim:rw"
     environment:
-      - VALIDATION_OPTION=NO_QUARANTINE
+      - VALIDATION_OPTION=NO_CHECK
     ports:
       - "1522:22"
     restart: always


### PR DESCRIPTION
Due to the current high load of the server and the fact we don't currently look at logs, we are disabling the quarantine.