### PR TITLE
Use our mirror to check size

### DIFF
--- a/library-docker/bin/library-to-catalog/library-to-catalog.py
+++ b/library-docker/bin/library-to-catalog/library-to-catalog.py
@@ -73,6 +73,7 @@ def get_local_size(fpath):
 
 def get_zim_url(url):
     ''' convert .zim.meta4 url to .zim one '''
+    url = url.replace("://download.kiwix.org/", "://mirror.download.kiwix.org/")
     purl = urlparse(url)
     path = purl.path
     fname = os.path.basename(url)


### PR DESCRIPTION
We make a HEAD request on ZIM files to find the actual size of the files.
Reusing the in-library URL, we'd end-up on whatever mirror while doing this.
We thus could end-up on HTTPS mirror while this doesn't handle it properly.
Make more sense to use the local server anyway (even though we go up the network stack)