### PR TITLE
back to using mirror manager

### DIFF
--- a/library-docker/bin/library-to-catalog/library-to-catalog.py
+++ b/library-docker/bin/library-to-catalog/library-to-catalog.py
@@ -73,7 +73,6 @@ def get_local_size(fpath):
 
 def get_zim_url(url):
     ''' convert .zim.meta4 url to .zim one '''
-    url = url.replace("://download.kiwix.org/", "://mirror.download.kiwix.org/")
     purl = urlparse(url)
     path = purl.path
     fname = os.path.basename(url)


### PR DESCRIPTION
Stop using specific mirror for url in ideascube YAML catalog