### PR TITLE
Fixed hotspot 2.4.0 master redirect

### DIFF
--- a/library-docker/bin/manageContentRepository.pl
+++ b/library-docker/bin/manageContentRepository.pl
@@ -280,7 +280,7 @@ sub writeRedirects {
     $content .= "/".$releaseDirectoryName."/kiwix-hotspot/kiwix-hotspot-win64.exe ".getLastRelease($releaseDirectory, "kiwix-hotspot-win64.exe")."\n";
 
     # Kiwix Hotspot master images have been moved, see https://github.com/kiwix/kiwix-hotspot/issues/576
-    $content .= "/release/kiwix-hotspot/master-images/2021-04-20/hotspot-master_2021-04-20_80c5f8e.img.zip /release/kiwix-hotspot/master/kiwix-hostpot_master_2021-04-20.img.zip\n";
+    $content .= "/release/kiwix-hotspot/master-images/2021-04-20/hotspot-master_2021-04-20_80c5f8e.img.zip /release/kiwix-hotspot/master/kiwix-hotspot_master_2021-04-22.img.zip\n";
     $content .= "/hotspots/base/hotspot-master_2019-08-24.img.zip /release/kiwix-hotspot/master/kiwix-hostpot_master_2019-08-24.img.zip\n";
 
     $content .= "/".$releaseDirectoryName."/kiwix-android/kiwix.apk ".getLastRelease($releaseDirectory, "kiwix-*.apk")."\n";


### PR DESCRIPTION
Hotspot versions uses the following images (hardcoded):

- `v2.3.8`: `/hotspots/base/hotspot-master_2019-08-24.img.zip`
- `v2.4.0`: `/release/kiwix-hotspot/master-images/2021-04-20/hotspot-master_2021-04-20_80c5f8e.img.zip`
- `v2.4.1`: `/release/kiwix-hotspot/master/kiwix-hostpot_master_2021-04-20.img.zip`  [bad]
- `v2.4.2`: `/release/kiwix-hotspot/master/kiwix-hostpot_master_2021-04-27.img.zip`

So we need to keep all those URLs working, except for the `2.4.1` one which is condemned.

It means we need the following files on server:

- `/release/kiwix-hotspot/master/kiwix-hostpot_master_2019-08-24.img.zip` for `<=2.3.8`, redir target from `/hotspots/base/hotspot-master_2019-08-24.img.zip`
- `/release/kiwix-hotspot/master/kiwix-hotspot_master_2021-04-22.img.zip` for `2.4.0` (it has `hotspot-master_2021-04-20_80c5f8e.img` inside), redir target from `/release/kiwix-hotspot/master-images/2021-04-20/hotspot-master_2021-04-20_80c5f8e.img.zip`
- `/release/kiwix-hotspot/master/kiwix-hostpot_master_2021-04-27.img.zip` for `2.4.2`

The first one already has the correct redirect
The third one has a bare file
The second one has a redirect that points to the wrong file. this fixes it