### PR TITLE
Include service worker info to ideascube catalog

### DIFF
--- a/library-docker/bin/library-to-catalog/library-to-catalog.py
+++ b/library-docker/bin/library-to-catalog/library-to-catalog.py
@@ -12,6 +12,10 @@ import hashlib
 import xml.etree.ElementTree as ET
 
 import yaml
+try:
+    from yaml import CSafeDumper as Dumper
+except ImportError:
+    from yaml import SafeDumper as Dumper
 import requests
 import pycountry
 
@@ -35,6 +39,7 @@ logger.setLevel(logging.DEBUG)
 
 with_checksum = True  # debug only
 with_size = True  # debug only
+
 
 def get_remote_checksum(url):
     ''' retrieve SHA-256 checksum of download using special mirrorbrain url '''
@@ -70,6 +75,7 @@ def get_remote_size(url):
 def get_local_size(fpath):
     ''' size in bytes of a local file '''
     return os.path.getsize(fpath)
+
 
 def get_zim_url(url):
     ''' convert .zim.meta4 url to .zim one '''
@@ -225,13 +231,14 @@ def convert(library_fpath, catalog_fpath, local_repository=False):
             'type': "zim",
             'langid': langid,
         }
+        if "_sw:yes" in tags:
+            catalog[langid].update({"sw": "y"})
 
     logger.info("finished parsing {nb} entries".format(nb=len(catalog.keys())))
 
     logger.info("dumping yaml content to file `{}`".format(catalog_fpath))
     with open(catalog_fpath, 'w') as fd:
-        yaml.safe_dump({'all': catalog}, fd,
-                       default_flow_style=False)
+        yaml.dump({'all': catalog}, fd, default_flow_style=False, Dumper=Dumper)
 
     logger.info("done converting library to catalog.")
 

--- a/library-docker/bin/library-to-catalog/requirements.pip
+++ b/library-docker/bin/library-to-catalog/requirements.pip
@@ -1,3 +1,3 @@
 pycountry==18.2.23
-PyYAML==3.12
+PyYAML==5.4.1
 requests==2.18.4


### PR DESCRIPTION
In order to adapt Kiwix Hotspot behavior based on Service Worker dependency, we need
the catalog to have that information in the first place.

This adds a new `sw:y` property to items that rely on service worker (ie. have the `_sw:yes` tag)

This was done specifically as to not increase much the size of this already quite large
catalog and the fact that we want to retire it soon in favor of OPDS.

Used this oportunity to update PyYAML and use the C libyaml parser to boost performances.