### PR TITLE
Prevent RW access from FTP in download folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - "21:21"
       - "30000-30050:30000-30050"
     volumes:
-      - "/data/download:/var/lib/ftp"
+      - "/data/download:/var/lib/ftp:ro"
     entrypoint:
       - /usr/local/sbin/dkr-init
       - -p


### PR DESCRIPTION
[PureFTPd image](https://github.com/gimoh/docker-pureftpd) we use doesn't seem to (at least easily) turn off RW for anonymous users.
Usage recommend to use filesystem's permissions for such use case.

As we want to prevent any accidental permission mistake to allow anonymous users to
upload files on the server, mounting the whole /data/download volume read-only seems
like a very safe option.