### PR TITLE
Main monitoring container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,8 +103,8 @@ services:
       - "/data/certs:/etc/nginx/certs:ro"
       - "/data/log/nginx:/var/log/nginx"
     environment:
-      - VIRTUAL_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org
-      - LETSENCRYPT_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org
+      - VIRTUAL_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org
+      - LETSENCRYPT_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org
       - LETSENCRYPT_EMAIL=contact@kiwix.org
       - HTTPS_METHOD=noredirect
     labels:
@@ -207,6 +207,25 @@ services:
       - HOST=download.openzim.org
     secrets:
       - matomo-token
+    restart: always
+
+  monitoring:
+    build: ./netdata
+    container_name: monitoring
+    volumes:
+      - "/data/monitoring/cache:/var/cache/netdata"
+      - "/etc/passwd:/host/etc/passwd:ro"
+      - "/etc/group:/host/etc/group:ro"
+      - "/proc:/host/proc:ro"
+      - "/sys:/host/sys:ro"
+      - "/etc/os-release:/host/etc/os-release:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    ports:
+      - "19999:19999"
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor=unconfined
     restart: always
 
 volumes:

--- a/netdata/Dockerfile
+++ b/netdata/Dockerfile
@@ -1,0 +1,21 @@
+FROM netdata/netdata:latest
+LABEL org.opencontainers.image.source https://github.com/kiwix/maintenance
+
+ENV DO_NOT_TRACK 1
+ENV NETDATA_HOSTNAME monitoring.openzim.org
+ENV STREAM_KEY 7DC0DDB8-8EAA-4391-AF5D-BE017EECF0EE
+
+COPY netdata.conf /etc/netdata/netdata.conf
+
+# disable all external modules
+RUN printf "enabled: no\n" | tee /etc/netdata/python.d.conf /etc/netdata/go.d.conf /etc/netdata/node.d.conf
+
+# add clean-up script
+RUN printf "#!/bin/bash\nrm -rf /var/cache/netdata/* && kill 1\n" \
+> /usr/local/bin/reset-netdata \
+&& chmod a+x /usr/local/bin/reset-netdata
+
+COPY entrypoint.sh /usr/local/bin/entrypoint
+RUN chmod a+x /usr/local/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]

--- a/netdata/README.md
+++ b/netdata/README.md
@@ -1,0 +1,72 @@
+maintenance-netdata
+===================
+
+A [netdata](https://github.com/netdata/netdata/) container to monitor zimfarm tasks.
+
+The objective is twofold:
+
+- receive directly-streamed *netdata* metrics from zimfarm workers which have monitoring enabled
+- monitor the server it's running on.
+
+Latter was not an initial objective but it's handy to have it since we don't monitor the other services.
+
+## Specifics
+
+- Available at https://monitoring.openzim.org/
+- Opens an external port `:19999` to receive data stream from workers (non-http traffic)
+- Uses a unique `[stream]` config for all workers with a single Key.
+- Blocks streaming from IPs not in the zimfarm workers pool.
+- `reset-netdata` script to clear all tasks' data.
+- Is expected to store data on behalf of zimfarm monitors which only stream it there.
+
+## Usage
+
+netdata is user-friendly but has quite many features. Check out [the dashboard docs](https://learn.netdata.cloud/guides/step-by-step/step-02) if you want to know more.
+
+### Monitoring Kiwix server
+
+To monitor the main Kiwix server, just make sure you have not selected any server on the left sidebar (URL does not contain `/host/xxxx`).
+
+All the metrics you see are for the main server. You should see the list of the docker containers on the right sidebar (bellow *Users*). When you select any container, you'll see a limited number of metrics (`cpu`, `mem`, `disk`), for this container.
+
+### Monitoring a Zimfarm task
+
+To monitor a Zimfarm task, you must select it from the *Replicated nodes* list in the left sidebar. If you are looking at it while it's running, a **live** indicator should be visible. Note: the URL now has a `/host/` prefix.
+
+If you are looking at it later-on, keep in mind that our data retention is based on storage usage and not time, so there is no expectable delay before eviction.
+
+You can download data from the dashboard though and import it back later or on a different netdata instance.
+
+_**Important**_: *Zimfarm monitors* **report metrics for their whole host** (the complete Zimfarm worker).
+
+You can check whether there were other tasks running during your monitored-task by looking at the list of containers on the right sidebar (bellow *Users*). If there are multiple `zimscraper` ones, be careful.
+
+If there is only a single scraper in your data, you can safely look at any metric.
+
+If there are multiple ones, you should click on the `zimscraper` one that interests you (check its ID) and look at the `cpu`, `mem` and `disk` stats available.
+
+#### Redis
+
+If the scraper you are monitoring is using redis and exposed it on the standard port (`sotoki` for instance), you can access _task-specific_, _redis-specific_ metrics by looking at the *Redis scraper* section of the right sidebar (after the containers). Those are very detailed.
+
+Unlike other non-container stats, this data is grabbed directly from the scraper container of that very task so it's not host-level compiled data.
+
+## Configuration
+
+https://learn.netdata.cloud/docs/configure/nodes
+
+Data retention can be set in `netdata.conf`. It is set in MiB .
+
+```yaml
+[global]
+ page size cache = 64  # uses 64MiB of RAM for cache
+ # uses 4GiB of storage space.
+ # ths is used as default for each stream receiver
+ # if not customized in stream.conf
+ dbengine disk space = 4096
+ # uses 4GiB os storage for all hosts
+ # that's our global limit
+ dbengine multihost disk space = 4096
+ # update all metrics every n seconds (1s is default)
+ update every = 1
+```

--- a/netdata/entrypoint.sh
+++ b/netdata/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# update stream allow from list using workers list on github
+WORKERS_URL=https://raw.githubusercontent.com/openzim/zimfarm/master/workers/contrib/workers.json
+IPS=$(echo -n $(curl -sS "${WORKERS_URL}" | jq --raw-output ".[]"))
+
+# write stream config
+read -d '' STREAM_CONF << EOF
+[${STREAM_KEY}]
+ enabled = yes
+ default history = 86400
+ default memory = dbengine
+ health enabled by default = auto
+ multiple connections = allow
+ allow from = ${IPS}
+EOF
+echo "${STREAM_CONF}" > /etc/netdata/stream.conf
+
+
+# setup custom hostname for node in netdata
+if [ ! -z "${NETDATA_HOSTNAME}" ]
+then
+    printf "\n hostname = ${NETDATA_HOSTNAME}\n" >> /etc/netdata/netdata.conf
+fi
+
+# netdata's entrypoint
+/usr/sbin/run.sh

--- a/netdata/netdata.conf
+++ b/netdata/netdata.conf
@@ -1,0 +1,13 @@
+# netdata can generate its own config which is available at 'http://<netdata_ip>/netdata.conf'
+# You can download it with command like: 'wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf'
+
+# keep [global] section on bottom so entrypoint can append hostname
+
+[web]
+ bind to = *
+
+[global]
+ page size cache = 64
+ dbengine disk space = 4096
+ dbengine multihost disk space = 4096
+ update every = 1

--- a/reverse-proxy-docker/sites/monitoring.openzim.org
+++ b/reverse-proxy-docker/sites/monitoring.openzim.org
@@ -1,0 +1,20 @@
+upstream backend {
+    server monitoring:19999;
+    keepalive 64;
+}
+
+server {
+    listen *:80;
+    server_name monitoring.openzim.org;
+
+    location / {
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_pass_request_headers on;
+        proxy_set_header Connection "keep-alive";
+        proxy_store off;
+    }
+}


### PR DESCRIPTION
A netdata container to receive the streams from Zimfarm monitors.
Also serves as a monitor for the server itself.

See README for additional details