### PR TITLE
Fixed #194: fixed certs renewal for monitoring and drive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,8 +117,8 @@ services:
       - "/data/certs:/etc/nginx/certs:ro"
       - "/data/log/nginx:/var/log/nginx"
     environment:
-      - VIRTUAL_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org,drive.farm.openzim.org
-      - LETSENCRYPT_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org,drive.farm.openzim.org
+      - VIRTUAL_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org
+      - LETSENCRYPT_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org
       - LETSENCRYPT_EMAIL=contact@kiwix.org
       - HTTPS_METHOD=noredirect
     labels:
@@ -134,7 +134,7 @@ services:
     restart: always
 
   letsencrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion:v1.13
     container_name: letsencrypt
     depends_on:
       - reverse-proxy

--- a/reverse-proxy-docker/Dockerfile
+++ b/reverse-proxy-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy:0.9.0
+FROM nginxproxy/nginx-proxy:0.9
 
 RUN apt-get update && apt-get install -y --no-install-recommends cron logrotate python3 curl patch
 

--- a/reverse-proxy-docker/sites/monitoring.openzim.org
+++ b/reverse-proxy-docker/sites/monitoring.openzim.org
@@ -7,6 +7,10 @@ server {
     listen *:80;
     server_name monitoring.openzim.org;
 
+    root /usr/share/nginx/html/;
+
+    include /etc/nginx/vhost.d/default;
+
     location / {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
Root cause was the fact that monitoring is using a custom vhost file.
In this case, it is required to include /etc/nginx/vhost.d/default
in the configuration as this file is on the shared volume between
nginx-proxy and acme-companion and is responsible for exposing the acme-challenge path.

Using this oportunity to update our base images to the latest compatible version