### PR TITLE
Adding offspot drive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,20 @@ services:
       - LETSENCRYPT_EMAIL=contact@openzim.org
     restart: always
 
+  offspot-drive:
+    image: ghcr.io/openzim/surfer
+    container_name: offspot-drive
+    volumes:
+      - "/data/offspot-drive:/data"
+    secrets:
+      - drive-password
+    environment:
+      - HTTPS_METHOD=redirect
+      - VIRTUAL_HOST=drive.offspot.it
+      - LETSENCRYPT_HOST=drive.offspot.it
+      - LETSENCRYPT_EMAIL=contact@openzim.org
+    restart: always
+
   matomo-download:
     image: ghcr.io/kiwix/matomo-log-analytics
     container_name: matomo-log-analytics_download

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - "/data/download/release:/storage/kiwix/release:ro"
       - "/data/download/screenshots:/storage/kiwix/screenshots:ro"
       - "/data/zimfarm-drive:/storage/zimfarm-drive:ro"
+      - "/data/offspot-drive:/storage/offspot-drive:ro"
     env_file:
       - .env_download_backup
     restart: always


### PR DESCRIPTION
Adding another drive for offspot projects.
This would mainly replaces the download.kiwix.org/other/ folder.

Chose `drive.offspot.it` but any other could do it.