### PR TITLE
building matomo in Github

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish Docker Image
-        uses: openzim/docker-publish-action@v5
+        uses: openzim/docker-publish-action@v6
         with:
           image-name: kiwix/library
           on-master: latest
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish Docker Image
-        uses: openzim/docker-publish-action@v5
+        uses: openzim/docker-publish-action@v6
         with:
           image-name: kiwix/mirrorbrain
           on-master: latest
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish Docker Image
-        uses: openzim/docker-publish-action@v5
+        uses: openzim/docker-publish-action@v6
         with:
           image-name: kiwix/reverse-proxy
           on-master: latest
@@ -63,12 +63,30 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish Docker Image
-        uses: openzim/docker-publish-action@v5
+        uses: openzim/docker-publish-action@v6
         with:
           image-name: kiwix/rsyncd
           on-master: latest
           restrict-to: kiwix/maintenance
           context: rsyncd-docker
+          registries: ghcr.io
+          credentials:
+            GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
+            GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
+
+  matomo:
+    name: Deploy matomo Image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Docker Image
+        uses: openzim/docker-publish-action@v6
+        with:
+          image-name: kiwix/matomo
+          on-master: latest
+          restrict-to: kiwix/maintenance
+          context: matomo-server-docker
+          dockerfile: Dockerfile-app
           registries: ghcr.io
           credentials:
             GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
@@ -80,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish Docker Image
-        uses: openzim/docker-publish-action@v5
+        uses: openzim/docker-publish-action@v6
         with:
           image-name: kiwix/matomo-log-analytics
           on-master: latest

--- a/matomo-server-docker/Dockerfile-app
+++ b/matomo-server-docker/Dockerfile-app
@@ -1,4 +1,4 @@
-FROM matomo:fpm
+FROM matomo:3.9.1-fpm
 
 ENV MATOMO_URL=http://stats.kiwix.org
 
@@ -6,10 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends cron && rm -r /
 
 RUN { \
     echo "5 * * * * www-data /usr/local/bin/php /var/www/html/console core:archive --url $MATOMO_URL" ; \
-  } > /etc/cron.d/matomo-archive && chmod 0500 /etc/cron.d/matomo-archive 
+  } > /etc/cron.d/matomo-archive && chmod 0500 /etc/cron.d/matomo-archive
 
 RUN { \
     echo "memory_limit = 512M" ; \
 } > /usr/local/etc/php/conf.d/memory-limit.ini
+
+COPY data/web/conf/config.ini.php /var/www/html/config/config.ini.php
 
 CMD service cron start && php-fpm

--- a/matomo-server-docker/docker-compose.yml
+++ b/matomo-server-docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: always
 
   app:
-    image: kiwix/matomo
+    image: ghcr.io/kiwix/matomo:latest
     container_name: matomo_app
     volumes:
       - "appdir:/var/www/html"


### PR DESCRIPTION
- Adding config.ini.php to image although it is in our mountpoint on our docker compose
- Using a fixed version of matomo source image (using previous one)
- building the image on github actions
- using ghcr image in compose