### PR TITLE
Removed monitoring.openzim.org from HTTPS list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - "/data/log/nginx:/var/log/nginx"
     environment:
       - VIRTUAL_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org
-      - LETSENCRYPT_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org,monitoring.openzim.org
+      - LETSENCRYPT_HOST=download.openzim.org,mirror.download.kiwix.org,tmp.kiwix.org
       - LETSENCRYPT_EMAIL=contact@kiwix.org
       - HTTPS_METHOD=noredirect
     labels:


### PR DESCRIPTION
For some reason, monitoring.openzim.org being in the reverse-proxy's letsencrypt list
makes the certificate renewal request for the reverse-proxy to fail (third party
python code raises an exception).
Given it's not necessary for this particular domain and the coming switch to k8s,
removing it is a interval fix.