### PR TITLE
Use HTTPS url for log upload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       - "/data/log/nginx:/var/log/nginx"
     environment:
       - ID_SITE=2
-      - URL=http://stats.kiwix.org
+      - URL=https://stats.kiwix.org
       - LOG=/var/log/nginx/access.log
       - HOST=download.kiwix.org
     secrets:
@@ -246,7 +246,7 @@ services:
       - "/data/log/nginx:/var/log/nginx"
     environment:
       - ID_SITE=6
-      - URL=http://stats.kiwix.org
+      - URL=https://stats.kiwix.org
       - LOG=/var/log/nginx/access.log
       - HOST=download.openzim.org
     secrets:


### PR DESCRIPTION
Server is configured with `assume_secure_protocol=1` which creates a 308 redirect
to https version which the log upload script complains about