### PR TITLE
Mirrorbrain: Fix computation of `WMDIRS` for scanning

### DIFF
--- a/mirrorbrain/bin/update_mirrorbrain_db.sh
+++ b/mirrorbrain/bin/update_mirrorbrain_db.sh
@@ -6,7 +6,7 @@ MB=/usr/local/bin/mb
 REPO="/var/www/download.kiwix.org/"
 ESCREPO=`echo "$REPO" | sed -e 's/[\\/&]/\\\\&/g'`
 ALLDIRS=`find "$REPO" -maxdepth 1 -type d | sed "s/$ESCREPO//"`
-WMDIRS=`find "$REPO" -type d -name "*wikipedia*" -o -type d -name "*wiktionary*" -o -type d -name "*wikisource*" -o -type d -name "*wikibooks*" -o -type d -name "*wikivoyage*" -o -type d -name "*wikiquote*" -o -type d -name "*wikinews*" -o -type d -name "*wikiversity*" -o -type d -name "*0.9*" | sed "s/$ESCREPO//" | grep -v -e "^archive/"`
+WMDIRS=`find "$REPO" -type d -name "*wikipedia*" -o -type d -name "*wiktionary*" -o -type d -name "*wikisource*" -o -type d -name "*wikibooks*" -o -type d -name "*wikivoyage*" -o -type d -name "*wikiquote*" -o -type d -name "*wikinews*" -o -type d -name "*wikiversity*" | sed "s/$ESCREPO//" | grep -v -e "^archive/"`
 ZIMDIRS="zim"
 
 function scanMirror() {


### PR DESCRIPTION
Update computation of `WMDIRS`:
- restore exclusion of `archive` folders which was removed by mistake by #248 
- remove duplicated inclusion of `*wikinews*`
- remove absent `*0.9*` folder

@kelson42 @rgaudin any remembering of why this `0.9` folder have been included at some point?