### PR TITLE
Update Ubuntu 24.10 kiwix-build CI image to 26.04 LTS

### DIFF
--- a/.github/workflows/kiwix-build_ci.yml
+++ b/.github/workflows/kiwix-build_ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ['linux/amd64']
-        variant: [f35, focal, jammy, x86-64_manylinux, alpine, noble, oracular]
+        variant: [f35, focal, jammy, x86-64_manylinux, alpine, noble, resolute]
         include:
           - variant: aarch64_manylinux
             platform: linux/arm64

--- a/kiwix-build_ci/resolute_builder.dockerfile
+++ b/kiwix-build_ci/resolute_builder.dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:oracular
+FROM ubuntu:resolute
 LABEL org.opencontainers.image.source=https://github.com/kiwix/container-images
 
 ENV LANG=C.UTF-8
-ENV OS_NAME=oracular
+ENV OS_NAME=resolute
 ENV DEBIAN_FRONTEND=noninteractive
 # QT_SELECT=qt6 with qtchooser allows building with 'qmake' instead of 'qmake6'
 ENV QT_SELECT=qt6
@@ -21,7 +21,7 @@ RUN apt update -q \
 # Qt packages
     qt6-base-dev qt6-base-dev-tools qt6-webengine-dev libqt6webenginecore6-bin libqt6svg6 qtchooser \
 # To create the appimage of kiwix-desktop
-    libfuse3-3 fuse3 patchelf \
+    libfuse3-4 fuse3 patchelf \
 # Flatpak tools
     elfutils flatpak flatpak-builder \
 # Cross win32 compiler


### PR DESCRIPTION
This is a follow-up of https://github.com/kiwix/container-images/pull/283

This replace the non-supported Ubuntu 24.10 _oracular_ with the Ubuntu 26.04 LTS (still to be released) version.

To the contrary to 24.10, this version has for purposed to be used everywhere where there is C++ to compile (so not only for Qt6 compilation with the image of 24.10).